### PR TITLE
Use cairo instead of cairo_wrapper

### DIFF
--- a/src/driver/cairo.php
+++ b/src/driver/cairo.php
@@ -100,7 +100,7 @@ class ezcGraphCairoDriver extends ezcGraphDriver
      */
     public function __construct( array $options = array() )
     {
-        ezcBase::checkDependency( 'Graph', ezcBase::DEP_PHP_EXTENSION, 'cairo_wrapper' );
+        ezcBase::checkDependency( 'Graph', ezcBase::DEP_PHP_EXTENSION, 'cairo' );
         $this->options = new ezcGraphCairoDriverOptions( $options );
     }
 
@@ -936,8 +936,8 @@ class ezcGraphCairoDriver extends ezcGraphDriver
 
         // Scale pattern to defined dimensions and move it to its destination position
         $matrix = cairo_matrix_multiply(
-            $move = cairo_matrix_create_translate( -$position->x, -$position->y ),
-            $scale = cairo_matrix_create_scale( $data[0] / $width, $data[1] / $height )
+            $move = CairoMatrix::initTranslate( -$position->x, -$position->y ),
+            $scale = CairoMatrix::initScale( $data[0] / $width, $data[1] / $height )
         );
         cairo_pattern_set_matrix( $pattern, $matrix );
 

--- a/tests/driver_cairo_test.php
+++ b/tests/driver_cairo_test.php
@@ -50,9 +50,9 @@ class ezcGraphCairoDriverTest extends ezcTestImageCase
 
     protected function setUp()
     {
-        if ( !ezcBaseFeatures::hasExtensionSupport( 'cairo_wrapper' ) )
+        if ( !ezcBaseFeatures::hasExtensionSupport( 'cairo' ) )
         {
-            $this->markTestSkipped( 'This test needs pecl/cairo_wrapper support.' );
+            $this->markTestSkipped( 'This test needs pecl/cairo support.' );
         }
 
         static $i = 0;


### PR DESCRIPTION
Hello,

  The pecl cairo_wrapper hasn't seen an update since 2008. The cairo pecl module seems to fulfill the graph's needs with the following changes. I couldn't run the tests however to make doubly sure. However it definitely works for us on a production machine at the moment.
