### PR TITLE
Add a position feature to the axes labels (good one)

### DIFF
--- a/src/element/axis.php
+++ b/src/element/axis.php
@@ -119,6 +119,8 @@
  *           Size of axis label
  * @property int $labelMargin
  *           Distance between label an axis
+ * @property int $labelPosition
+ *           Integer defining the labels position regarding the axe.
  * @property int $minArrowHeadSize
  *           Minimum Size used to draw arrow heads.
  * @property int $maxArrowHeadSize
@@ -179,6 +181,7 @@ abstract class ezcGraphChartElementAxis extends ezcGraphChartElement
         $this->properties['label'] = false;
         $this->properties['labelSize'] = 14;
         $this->properties['labelMargin'] = 2;
+        $this->properties['labelPosition'] = ezcGraph::LEFT;
         $this->properties['minArrowHeadSize'] = 4;
         $this->properties['maxArrowHeadSize'] = 8;
         $this->properties['labelCallback'] = null;
@@ -295,6 +298,23 @@ abstract class ezcGraphChartElementAxis extends ezcGraphChartElement
                 }
                 
                 $this->properties['labelMargin'] = (int) $propertyValue;
+                break;
+            case 'labelPosition':
+                $positions = array(
+                    ezcGraph::TOP,
+                    ezcGraph::BOTTOM,
+                    ezcGraph::LEFT,
+                    ezcGraph::RIGHT,
+                );
+
+                if ( in_array( $propertyValue, $positions, true ) )
+                {
+                    $this->properties['labelPosition'] = $propertyValue;
+                }
+                else 
+                {
+                    throw new ezcBaseValueException( 'labelPosition', $propertyValue, 'integer' );
+                }
                 break;
             case 'maxArrowHeadSize':
                 if ( !is_numeric( $propertyValue ) ||

--- a/src/renderer/axis_label_exact.php
+++ b/src/renderer/axis_label_exact.php
@@ -207,6 +207,31 @@ class ezcGraphAxisExactLabelRenderer extends ezcGraphAxisLabelRenderer
                         // Skip last step if showLastValue is false
                         $showLabel = false;
                         break;
+                    // NTH : Draw label at top right of step on vertical axis
+                   case ( ( $axis->labelPosition === ezcGraph::RIGHT ) &&
+                        ( !$step->isLast ) ) ||
+                        ( ( $axis->labelPosition === ezcGraph::RIGHT ) &&
+                        ( $step->isLast ) &&
+                        ( $this->renderLastOutside ) ) :
+                        $labelBoundings = new ezcGraphBoundings(
+                            $position->x + $this->labelPadding,
+                            $position->y - $labelHeight + $this->labelPadding,
+                            $position->x + $labelWidth - $this->labelPadding,
+                            $position->y - $this->labelPadding
+                        );
+                        $alignement = ezcGraph::LEFT | ezcGraph::BOTTOM;
+                        break;
+                   case ( ( $axis->labelPosition === ezcGraph::RIGHT ) &&
+                        ( $step->isLast ) &&
+                        ( !$this->renderLastOutside ) ) :
+                        $labelBoundings = new ezcGraphBoundings(
+                            $position->x + $this->labelPadding,
+                            $position->y + $this->labelPadding,
+                            $position->x + $labelWidth - $this->labelPadding,
+                            $position->y + $labelHeight - $this->labelPadding
+                        );
+                        $alignement = ezcGraph::TOP | ezcGraph::LEFT;
+                        break;
                     // Draw label at top left of step
                     case ( ( $axis->position === ezcGraph::BOTTOM ) &&
                            ( !$step->isLast ) ) ||


### PR DESCRIPTION
I just commit the minimum code to allow labels on the right of a vertical secondary axis.
only $axis->labelPosition === ezcGraph::RIGHT is supported.

this allows to put the labels on the right. specially usefull when you have a linebar graph with a secondary axes on the right, you want the labels to be symetric with the mein axis.
