### PR TITLE
Width guess function for decimals

### DIFF
--- a/src/driver/svg.php
+++ b/src/driver/svg.php
@@ -585,7 +585,9 @@ class ezcGraphSvgDriver extends ezcGraphDriver
 
         if ( is_numeric( $string ) )
         {
-            return $size * strlen( $string ) * $this->options->assumedNumericCharacterWidth;
+        	$length = strlen( $string );
+        	if (preg_match('/[.,]/', $string)) $length = $length - 0.9;
+            return $size * $length * $this->options->assumedNumericCharacterWidth;
         }
         else
         {


### PR DESCRIPTION
There are special chars in decimals that don't have the same width as
numeric chars (10% of a numeric width).

So when there is one, we must reduce the string length of 0.9 char.
