### PR TITLE
Revert unnecessary require for the GD extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,10 +51,12 @@
     "name": "zetacomponents/graph",
     "type": "library",
         "require": {
-            "ext-gd": "*",
             "zetacomponents/base": "~1.8"
         },
         "require-dev": {
             "zetacomponents/unit-test": "*"
+        },
+        "suggest": {
+            "ext-gd": "Used by the GD driver, one of the choices for generating bitmap images."
         }
 }


### PR DESCRIPTION
GD is only necessary for the GD Driver which is not the default driver.

There's not reason to force all users to install the GD extension and so we can simply suggest that they include it if they want to use that driver.
