### PR TITLE
avoid float precision issue

### DIFF
--- a/tests/dataset_average_test.php
+++ b/tests/dataset_average_test.php
@@ -334,7 +334,7 @@ class ezcGraphDataSetAverageTest extends ezcGraphTestCase
 
         foreach ( $averageDataSet as $key => $value )
         {
-            $this->assertEquals( (string) ( $start += $stepSize ), $key, 'Wrong step.', .01 );
+            $this->assertEquals( (string) ( round($start += $stepSize,12) ), $key, 'Wrong step.');
         }
     }
 


### PR DESCRIPTION
Running test suite with phpunit 4.6.10

    There was 1 failure:
    
    1) ezcGraphDataSetAverageTest::testIterateOverAverageDataset2
    Wrong step.
    Failed asserting that two strings are equal.
    --- Expected
    +++ Actual
    @@ @@
    -'3.4694469519536E-16'
    +'0'

Looks like a simple float precision issue.