### PR TITLE
Enable stacked rendering for horizontal bar charts

### DIFF
--- a/src/charts/line.php
+++ b/src/charts/line.php
@@ -276,7 +276,12 @@ class ezcGraphLineChart extends ezcGraphChart
             $yAxis = ( $data->yAxis->default ? $data->yAxis->default: $this->elements['yAxis'] );
 
             // Determine fill color for dataset
-            if ( $this->options->fillLines !== false )
+            if ( $data->fillLine !== false )
+            {
+                $fillColor = clone $data->color->default;
+                $fillColor->alpha = (int) round( ( 255 - $fillColor->alpha ) * ( $data->fillLine / 255 ) );
+            }
+            else if ( $this->options->fillLines !== false )
             {
                 $fillColor = clone $data->color->default;
                 $fillColor->alpha = (int) round( ( 255 - $fillColor->alpha ) * ( $this->options->fillLines / 255 ) );

--- a/src/charts/radar.php
+++ b/src/charts/radar.php
@@ -296,6 +296,7 @@ class ezcGraphRadarChart extends ezcGraphChart
 
         // Display data
         $this->elements['axis']->position = ezcGraph::TOP;
+        $prevDataSetPoints = array();
         foreach ( $this->data as $datasetName => $data )
         {
             --$nr;
@@ -315,8 +316,11 @@ class ezcGraphRadarChart extends ezcGraphChart
                 $fillColor = null;
             }
 
+            $prevDataSetBounded = $data->boundFillToPreviousDataSet;
+
             // Draw lines for dataset
             $lastPoint = false;
+            $lastInnerPoint = false;
             foreach ( $data as $key => $value )
             {
                 $point = new ezcGraphCoordinate( 
@@ -336,6 +340,16 @@ class ezcGraphRadarChart extends ezcGraphChart
                 ); 
                 // */
 
+                if ($prevDataSetBounded && array_key_exists($key, $prevDataSetPoints)) {
+                    $innerPoint = $prevDataSetPoints[$key];
+                }
+                else {
+                    $innerPoint = new ezcGraphCoordinate(
+                        0,
+                        0
+                    );
+                }
+
                 $renderer->drawRadarDataLine(
                     $boundings,
                     new ezcGraphContext( $datasetName, $key, $data->url[$key] ),
@@ -343,6 +357,8 @@ class ezcGraphRadarChart extends ezcGraphChart
                     clone $center,
                     ( $lastPoint === false ? $point : $lastPoint ),
                     $point,
+                    $innerPoint,
+                    ( $lastInnerPoint === false ? $innerPoint : $lastInnerPoint ),
                     $nr,
                     $count,
                     $data->symbol[$key],
@@ -351,7 +367,10 @@ class ezcGraphRadarChart extends ezcGraphChart
                     $this->options->lineThickness
                 );
 
+                $prevDataSetPoints[$key] = $point;
+
                 $lastPoint = $point;
+                $lastInnerPoint = $innerPoint;
             }
         }
     }

--- a/src/charts/radar.php
+++ b/src/charts/radar.php
@@ -300,7 +300,12 @@ class ezcGraphRadarChart extends ezcGraphChart
         {
             --$nr;
             // Determine fill color for dataset
-            if ( $this->options->fillLines !== false )
+            if ( $data->fillLine !== false )
+            {
+                $fillColor = clone $data->color->default;
+                $fillColor->alpha = (int) round( ( 255 - $fillColor->alpha ) * ( $data->fillLine / 255 ) );
+            }
+            else if ( $this->options->fillLines !== false )
             {
                 $fillColor = clone $data->color->default;
                 $fillColor->alpha = (int) round( ( 255 - $fillColor->alpha ) * ( $this->options->fillLines / 255 ) );

--- a/src/datasets/base.php
+++ b/src/datasets/base.php
@@ -37,6 +37,9 @@
  *           Displayed string if a data point is highlighted
  * @property bool $highlight
  *           Status if datapoint element is hilighted
+ * @property mixed $fillLine
+ *           Interpretation depends on underlying chart type
+ *           @see chart type fillLines option for details
  * @property int $displayType
  *           Display type of chart data
  * @property string $url
@@ -110,6 +113,7 @@ abstract class ezcGraphDataSet implements ArrayAccess, Iterator, Countable
         $this->properties['yAxis'] = new ezcGraphDataSetAxisProperty( $this );
 
         $this->properties['highlight']->default = false;
+        $this->properties['fillLine'] = false;
     }
 
     /**
@@ -147,6 +151,21 @@ abstract class ezcGraphDataSet implements ArrayAccess, Iterator, Countable
                 $this->palette = $propertyValue;
                 $this->color->default = $this->palette->dataSetColor;
                 $this->symbol->default = $this->palette->dataSetSymbol;
+                break;
+
+            case 'fillLine':
+                if ( ( $propertyValue !== false ) &&
+                     !is_numeric( $propertyValue ) ||
+                     ( $propertyValue < 0 ) ||
+                     ( $propertyValue > 255 ) )
+                {
+                    throw new ezcBaseValueException( $propertyName, $propertyValue, 'false OR 0 <= int <= 255' );
+                }
+
+                $this->properties[$propertyName] = (
+                    $propertyValue === false
+                    ? false
+                    : (int) $propertyValue );
                 break;
 
             default:

--- a/src/datasets/base.php
+++ b/src/datasets/base.php
@@ -40,6 +40,10 @@
  * @property mixed $fillLine
  *           Interpretation depends on underlying chart type
  *           @see chart type fillLines option for details
+ * @property bool $boundFillToPreviousDataSet
+ *           Only fill the region between the current data set
+ *           and the previous data set.  Only works for radar
+ *           plots at this time.  @see $fillLine property.
  * @property int $displayType
  *           Display type of chart data
  * @property string $url
@@ -114,6 +118,7 @@ abstract class ezcGraphDataSet implements ArrayAccess, Iterator, Countable
 
         $this->properties['highlight']->default = false;
         $this->properties['fillLine'] = false;
+        $this->properties['boundFillToPreviousDataSet'] = false;
     }
 
     /**
@@ -166,6 +171,10 @@ abstract class ezcGraphDataSet implements ArrayAccess, Iterator, Countable
                     $propertyValue === false
                     ? false
                     : (int) $propertyValue );
+                break;
+
+            case 'boundFillToPreviousDataSet':
+                $this->properties[$propertyName] = $propertyValue;
                 break;
 
             default:

--- a/src/interfaces/radar_renderer.php
+++ b/src/interfaces/radar_renderer.php
@@ -58,6 +58,8 @@ interface ezcGraphRadarRenderer
         ezcGraphCoordinate $center,
         ezcGraphCoordinate $start,
         ezcGraphCoordinate $end,
+        ezcGraphCoordinate $fillStart,
+        ezcGraphCoordinate $fillEnd,
         $dataNumber = 1,
         $dataCount = 1,
         $symbol = ezcGraph::NO_SYMBOL,

--- a/src/renderer/2d.php
+++ b/src/renderer/2d.php
@@ -884,6 +884,8 @@ class ezcGraphRenderer2d
         ezcGraphCoordinate $center,
         ezcGraphCoordinate $start,
         ezcGraphCoordinate $end,
+        ezcGraphCoordinate $fillStart,
+        ezcGraphCoordinate $fillEnd,
         $dataNumber = 1,
         $dataCount = 1,
         $symbol = ezcGraph::NO_SYMBOL,
@@ -905,6 +907,18 @@ class ezcGraphRenderer2d
             $end->x * 2 * M_PI,
             $end->y
         );
+        $fillStart = $this->getCoordinateFromAngleAndRadius(
+            $boundings,
+            $center,
+            $fillStart->x * 2 * M_PI,
+            $fillStart->y
+        );
+        $fillEnd = $this->getCoordinateFromAngleAndRadius(
+            $boundings,
+            $center,
+            $fillEnd->x * 2 * M_PI,
+            $fillEnd->y
+        );
 
         // Fill line
         if ( $fillColor !== null )
@@ -913,10 +927,8 @@ class ezcGraphRenderer2d
                 array(
                     $start,
                     $end,
-                    new ezcGraphCoordinate(
-                        $boundings->x0 + $center->x,
-                        $boundings->y0 + $center->y
-                    ),
+                    $fillStart,
+                    $fillEnd
                 ),
                 $fillColor,
                 true

--- a/src/renderer/horizontal_bar.php
+++ b/src/renderer/horizontal_bar.php
@@ -118,6 +118,76 @@ class ezcGraphHorizontalRenderer
     }
     
     /**
+     * Draw horizontal stacked bar
+     *
+     * Draws a horizontal stacked bar part as a data element in a line chart
+     * 
+     * @param ezcGraphBoundings $boundings Chart boundings
+     * @param ezcGraphContext $context Context of call
+     * @param ezcGraphColor $color Color of line
+     * @param ezcGraphCoordinate $start
+     * @param ezcGraphCoordinate $position
+     * @param float $stepSize Space which can be used for bars
+     * @param int $symbol Symbol to draw for line
+     * @param float $axisPosition Position of axis for drawing filled lines
+     * @return void
+     */
+    public function drawHorizontalStackedBar(
+        ezcGraphBoundings $boundings,
+        ezcGraphContext $context,
+        ezcGraphColor $color,
+        ezcGraphCoordinate $start,
+        ezcGraphCoordinate $position,
+        $stepSize,
+        $symbol = ezcGraph::NO_SYMBOL,
+        $axisPosition = 0. )
+    {
+        // Apply margin
+        $margin = $stepSize * $this->options->barMargin;
+        $barHeight = $stepSize - $margin;
+        $offset = - $stepSize / 2 + $margin / 2;
+
+        $barPointArray = array(
+            new ezcGraphCoordinate(
+                $boundings->x0 + ( $boundings->width ) * $start->x,
+                $boundings->y0 + ( $boundings->height ) * $position->y + $offset
+            ),
+            new ezcGraphCoordinate(
+                $boundings->x0 + ( $boundings->width ) * $position->x,
+                $boundings->y0 + ( $boundings->height ) * $position->y + $offset
+            ),
+            new ezcGraphCoordinate(
+                $boundings->x0 + ( $boundings->width ) * $position->x,
+                $boundings->y0 + ( $boundings->height ) * $position->y + $offset + $barHeight
+            ),
+            new ezcGraphCoordinate(
+                $boundings->x0 + ( $boundings->width ) * $start->x,
+                $boundings->y0 + ( $boundings->height ) * $position->y + $offset + $barHeight
+            ),
+        );
+
+        $this->addElementReference(
+            $context,
+            $this->driver->drawPolygon(
+                $barPointArray,
+                $color,
+                true
+            )
+        );
+
+        if ( $this->options->dataBorder > 0 )
+        {
+            $darkened = $color->darken( $this->options->dataBorder );
+            $this->driver->drawPolygon(
+                $barPointArray,
+                $darkened,
+                false,
+                1
+            );
+        }
+    }
+    
+    /**
      * Draw bar
      *
      * Draws a bar as a data element in a line chart

--- a/tests/renderer_horizontal_bar_test.php
+++ b/tests/renderer_horizontal_bar_test.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * ezcGraphHorizontalRendererTest 
+ * 
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * @package Graph
+ * @version //autogen//
+ * @subpackage Tests
+ * @license http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
+ */
+
+require_once dirname( __FILE__ ) . '/test_case.php';
+
+/**
+ * Tests for ezcGraph class.
+ * 
+ * @package Graph
+ * @subpackage Tests
+ */
+class ezcGraphHorizontalRendererTest extends ezcGraphTestCase
+{
+    protected $basePath;
+
+    protected $tempDir;
+
+    protected $renderer;
+
+    protected $driver;
+
+	public static function suite()
+	{
+	    return new PHPUnit_Framework_TestSuite( "ezcGraphHorizontalRendererTest" );
+	}
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        static $i = 0;
+        if ( version_compare( phpversion(), '5.1.3', '<' ) )
+        {
+            $this->markTestSkipped( "This test requires PHP 5.1.3 or later." );
+        }
+
+        $this->tempDir = $this->createTempDir( __CLASS__ . sprintf( '_%03d_', ++$i ) ) . '/';
+        $this->basePath = dirname( __FILE__ ) . '/data/';
+
+        $this->renderer = new ezcGraphHorizontalRenderer();
+
+        $this->driver = $this->getMockBuilder( 'ezcGraphSvgDriver' )
+            ->enableArgumentCloning()
+            ->setMethods( array(
+                'drawPolygon',
+                'drawLine',
+                'drawTextBox',
+                'drawCircleSector',
+                'drawCircularArc',
+                'drawCircle',
+                'drawImage',
+            ) )->getMock();
+        $this->renderer->setDriver( $this->driver );
+
+        $this->driver->options->width= 400;
+        $this->driver->options->height= 200;
+    }
+
+    public function tearDown()
+    {
+        $this->driver = null;
+        $this->renderer = null;
+
+        if ( !$this->hasFailed() )
+        {
+            $this->removeTempDir();
+        }
+    }
+// /*
+
+    public function testRenderHorizontalStackedBar()
+    {
+        $this->driver
+            ->expects( $this->at( 0 ) )
+            ->method( 'drawPolygon' )
+            ->with(
+                $this->equalTo( array( 
+                    new ezcGraphCoordinate( 200, 75. ),
+                    new ezcGraphCoordinate( 200, 75. ),
+                    new ezcGraphCoordinate( 200, 165. ),
+                    new ezcGraphCoordinate( 200, 165. ),
+                ), 1. ),
+                $this->equalTo( ezcGraphColor::fromHex( '#FF0000' ) ),
+                $this->equalTo( true )
+            );
+        $this->driver
+            ->expects( $this->at( 1 ) )
+            ->method( 'drawPolygon' )
+            ->with(
+                $this->equalTo( array( 
+                    new ezcGraphCoordinate( 200, 75. ),
+                    new ezcGraphCoordinate( 200, 75. ),
+                    new ezcGraphCoordinate( 200, 165. ),
+                    new ezcGraphCoordinate( 200, 165. ),
+                ), 1. ),
+                $this->equalTo( ezcGraphColor::fromHex( '#800000' ) ),
+                $this->equalTo( false )
+            );
+
+        $this->renderer->drawHorizontalStackedBar( 
+            new ezcGraphBoundings( 0, 0, 400, 200 ),
+            new ezcGraphContext(),
+            ezcGraphColor::fromHex( '#FF0000' ), 
+            new ezcGraphCoordinate( .5, .2 ),
+            new ezcGraphCoordinate( .5, .6 ),
+            100,
+            0
+        );
+    }
+}
+?>


### PR DESCRIPTION
This enables proper rendering of horizontal bar charts in stacked mode.  This is functionally identical to the vertical mode.