### PR TITLE
Interpret labels as UTF-8 in testFitStringInTextBox

### DIFF
--- a/src/interfaces/driver.php
+++ b/src/interfaces/driver.php
@@ -503,7 +503,7 @@ abstract class ezcGraphDriver
     protected function testFitStringInTextBox( $string, ezcGraphCoordinate $position, $width, $height, $size )
     {
         // Tokenize String
-        $tokens = preg_split( '/\s+/', $string );
+        $tokens = preg_split( '/\s+/u', $string );
         $initialHeight = $height;
 
         $lines = array( array() );


### PR DESCRIPTION
This fixes labels not showing up when certain characters,
e.g. "à", were used in those labels.

This fixes issue #4 

Signed-off-by: Timothy Pearson tpearson@raptorengineering.com
