### PR TITLE
PHP 7.2 deprecation fixes

### DIFF
--- a/docs/tutorial/tutorial_dataset_numeric.php
+++ b/docs/tutorial/tutorial_dataset_numeric.php
@@ -11,10 +11,7 @@ $graph->xAxis = new ezcGraphChartElementNumericAxis();
 $graph->data['sinus'] = new ezcGraphNumericDataSet( 
     -360, // Start value
     360,  // End value
-    create_function(
-        '$x',
-        'return sin( deg2rad( $x ) );'
-    )
+    function ( $x ) { return sin( deg2rad( $x ) ); }
 );
 
 $graph->data['sinus']->resolution = 120;

--- a/src/driver/svg.php
+++ b/src/driver/svg.php
@@ -616,11 +616,8 @@ class ezcGraphSvgDriver extends ezcGraphDriver
                 // Manual escaping of non ANSII characters, because ext/DOM fails here
                 return preg_replace_callback( 
                     '/[\\x80-\\xFF]/', 
-                    create_function(
-                        '$char',
-                        'return sprintf( \'&#x%02x;\', ord( $char[0] ) );'
-                    ),
-                    $string 
+                    function ( $char ) { return sprintf( '&#x%02x;', ord( $char[0] ) ); },
+                    $string
                 );
         }
     }

--- a/tests/dataset_numeric_test.php
+++ b/tests/dataset_numeric_test.php
@@ -221,11 +221,8 @@ class ezcGraphNumericDataSetTest extends ezcGraphTestCase
     {
         $numericDataSet = new ezcGraphNumericDataSet( 
             -90, 
-            90, 
-            create_function( 
-                '$x',
-                'return 10 * sin( deg2rad( $x ) );'
-            )
+            90,
+            function ( $x ) { return 10 * sin( deg2rad( $x ) ); }
         );
         $numericDataSet->resolution = 180;
 
@@ -247,21 +244,15 @@ class ezcGraphNumericDataSetTest extends ezcGraphTestCase
         $filename = $this->tempDir . __FUNCTION__ . '.svg';
 
         $chart = new ezcGraphLineChart();
-        $chart->data['Sinus'] = new ezcGraphNumericDataSet( 
-            -180, 
-            180, 
-            create_function( 
-                '$x',
-                'return 10 * sin( deg2rad( $x ) );'
-            )
+        $chart->data['Sinus'] = new ezcGraphNumericDataSet(
+            -180,
+            180,
+            function ( $x ) { return 10 * sin( deg2rad( $x ) ); }
         );
-        $chart->data['Cosinus'] = new ezcGraphNumericDataSet( 
+        $chart->data['Cosinus'] = new ezcGraphNumericDataSet(
             -180, 
-            180, 
-            create_function( 
-                '$x',
-                'return 5 * cos( deg2rad( $x ) );'
-            )
+            180,
+            function ( $x ) { return 5 * cos( deg2rad( $x ) ); }
         );
         $chart->xAxis = new ezcGraphChartElementNumericAxis();
 

--- a/tests/date_axis_test.php
+++ b/tests/date_axis_test.php
@@ -521,10 +521,7 @@ class ezcGraphDateAxisTest extends ezcGraphTestCase
             '1.1.2003' => 324,
             '1.1.2004' => 324,
         ) );
-        $this->chart->xAxis->labelCallback = create_function(
-            '$label',
-            'return "*$label*";'
-        );
+        $this->chart->xAxis->labelCallback = function( $label ) { return "*$label*"; };
 
         try
         {

--- a/tests/labeled_axis_test.php
+++ b/tests/labeled_axis_test.php
@@ -659,10 +659,7 @@ class ezcGraphLabeledAxisTest extends ezcGraphTestCase
         {
             $chart = new ezcGraphLineChart();
 
-            $chart->xAxis->labelCallback = create_function(
-                '$label',
-                'return "*$label*";'
-            );
+            $chart->xAxis->labelCallback = function( $label ) { return "*$label*"; };
 
             $chart->data['sample'] = new ezcGraphArrayDataSet( array( 2000 => 1045, 2001 => 1300, 2004 => 1012 ) );
             $chart->render( 500, 200 );

--- a/tests/logarithmical_axis_test.php
+++ b/tests/logarithmical_axis_test.php
@@ -455,10 +455,7 @@ class ezcGraphLogarithmicalAxisTest extends ezcGraphTestCase
             $chart = new ezcGraphLineChart();
 
             $chart->yAxis = new ezcGraphChartElementLogarithmicalAxis();
-            $chart->yAxis->labelCallback = create_function(
-                '$label',
-                'return "*$label*";'
-            );
+            $chart->yAxis->labelCallback = function( $label ) { return "*$label*"; };
 
             $chart->data['sample'] = new ezcGraphArrayDataSet( array( .03, 12, 43, 1023, .02, 1.5, 9823 ) );
 

--- a/tests/numeric_axis_test.php
+++ b/tests/numeric_axis_test.php
@@ -1078,10 +1078,7 @@ class ezcGraphNumericAxisTest extends ezcTestCase
         {
             $chart = new ezcGraphLineChart();
 
-            $chart->yAxis->labelCallback = create_function(
-                '$label',
-                'return "*$label*";'
-            );
+            $chart->yAxis->labelCallback = function( $label ) { return "*$label*"; };
 
             $chart->data['sampleData'] = new ezcGraphArrayDataSet( array( 'sample 1' => 234, 'sample 2' => -21, 'sample 3' => 324, 'sample 4' => 120, 'sample 5' => 1) );
             $chart->render( 500, 200 );

--- a/tests/pie_test.php
+++ b/tests/pie_test.php
@@ -337,11 +337,7 @@ class ezcGraphPieChartTest extends ezcGraphTestCase
 
         $chart->data['sample']->highlight['wget'] = true;
 
-        $chart->options->labelCallback = 
-            create_function( 
-                '$label, $value, $percent', 
-                "return 'Callback: ' . \$label;"
-            );
+        $chart->options->labelCallback = function( $label, $value, $percent ) { return 'Callback: ' . $label; };
 
         $mockedRenderer = $this->getMock( 'ezcGraphRenderer2d', array(
             'drawPieSegment',


### PR DESCRIPTION
Fixes:

```
 PHP | File:Line                                                                                          |             Type | Issue
 7.2 | /docs/tutorial/tutorial_dataset_numeric.php:14                                                     | function         | Function create_function() is deprecated. 
 7.2 | /src/driver/svg.php:619                                                                            | function         | Function create_function() is deprecated. 
 7.2 | /tests/dataset_numeric_test.php:225                                                                | function         | Function create_function() is deprecated. 
 7.2 | /tests/dataset_numeric_test.php:253                                                                | function         | Function create_function() is deprecated. 
 7.2 | /tests/dataset_numeric_test.php:261                                                                | function         | Function create_function() is deprecated. 
 7.2 | /tests/date_axis_test.php:524                                                                      | function         | Function create_function() is deprecated. 
 7.2 | /tests/labeled_axis_test.php:662                                                                   | function         | Function create_function() is deprecated. 
 7.2 | /tests/logarithmical_axis_test.php:458                                                             | function         | Function create_function() is deprecated. 
 7.2 | /tests/numeric_axis_test.php:1081                                                                  | function         | Function create_function() is deprecated. 
 7.2 | /tests/pie_test.php:341                                                                            | function         | Function create_function() is deprecated. 
```