### PR TITLE
Fix deprecated usage of implode

### DIFF
--- a/src/options/svg_driver.php
+++ b/src/options/svg_driver.php
@@ -166,7 +166,7 @@ class ezcGraphSvgDriverOptions extends ezcGraphDriverOptions
                 }
                 else
                 {
-                    throw new ezcBaseValueException( $propertyName, $propertyValue, implode( $values, ', ' ) );
+                    throw new ezcBaseValueException( $propertyName, $propertyValue, implode( ', ', $values ) );
                 }
                 break;
             case 'strokeLineCap':
@@ -183,7 +183,7 @@ class ezcGraphSvgDriverOptions extends ezcGraphDriverOptions
                 }
                 else
                 {
-                    throw new ezcBaseValueException( $propertyName, $propertyValue, implode( $values, ', ' ) );
+                    throw new ezcBaseValueException( $propertyName, $propertyValue, implode( ', ', $values ) );
                 }
                 break;
             case 'shapeRendering':
@@ -201,7 +201,7 @@ class ezcGraphSvgDriverOptions extends ezcGraphDriverOptions
                 }
                 else
                 {
-                    throw new ezcBaseValueException( $propertyName, $propertyValue, implode( $values, ', ' ) );
+                    throw new ezcBaseValueException( $propertyName, $propertyValue, implode( ', ', $values ) );
                 }
                 break;
             case 'colorRendering':
@@ -218,7 +218,7 @@ class ezcGraphSvgDriverOptions extends ezcGraphDriverOptions
                 }
                 else
                 {
-                    throw new ezcBaseValueException( $propertyName, $propertyValue, implode( $values, ', ' ) );
+                    throw new ezcBaseValueException( $propertyName, $propertyValue, implode( ', ', $values ) );
                 }
                 break;
             case 'textRendering':
@@ -236,7 +236,7 @@ class ezcGraphSvgDriverOptions extends ezcGraphDriverOptions
                 }
                 else
                 {
-                    throw new ezcBaseValueException( $propertyName, $propertyValue, implode( $values, ', ' ) );
+                    throw new ezcBaseValueException( $propertyName, $propertyValue, implode( ', ', $values ) );
                 }
                 break;
             case 'templateDocument':


### PR DESCRIPTION
This pr fixes some deprecated usages of [implode](https://www.php.net/manual/en/function.implode.php).

We stumbled across this issue using the library on php 7.4.

I was not able to run the whole test suite without further modifications because of updates in https://github.com/zetacomponents/UnitTest, for example, which uses a newer version of phpunit. I tried to update the tests but it is really tedious, therefore I stopped trying to do so.

I hope you are accepting this pr without a running test suite, the changes are small and, hopefully, be acknowledgeable without knowing the tests are green. :wink: 

I think fixing the tests is another topic and not in the scope of this pr.
However, since I already started looking into the tests, I may create another pr, later.