### PR TITLE
Adds "fillLine" option on dataSet to override global fillLines

### DIFF
--- a/docs/tutorial.txt
+++ b/docs/tutorial.txt
@@ -217,7 +217,7 @@ the default display type to ezcGraph::LINE. To more prominently display the
 line, we set one graph option in line 16. Options are accessed like public
 properties and in this case we set an option for the graph called "fillLines",
 which indicates what transparency value is used to fill the space underneath
-the line.
+the line. Alternatively you can set "fillLine" on individual datasets.
 
 .. image:: img/tutorial_bar_line_chart.svg.png
    :alt:   Combined bar and line chart

--- a/src/charts/line.php
+++ b/src/charts/line.php
@@ -276,7 +276,12 @@ class ezcGraphLineChart extends ezcGraphChart
             $yAxis = ( $data->yAxis->default ? $data->yAxis->default: $this->elements['yAxis'] );
 
             // Determine fill color for dataset
-            if ( $this->options->fillLines !== false )
+            if ( $data->fillLine !== false )
+            {
+                $fillColor = clone $data->color->default;
+                $fillColor->alpha = (int) round( ( 255 - $fillColor->alpha ) * ( $data->fillLine / 255 ) );
+            }
+            else if ( $this->options->fillLines !== false )
             {
                 $fillColor = clone $data->color->default;
                 $fillColor->alpha = (int) round( ( 255 - $fillColor->alpha ) * ( $this->options->fillLines / 255 ) );

--- a/src/charts/radar.php
+++ b/src/charts/radar.php
@@ -300,7 +300,12 @@ class ezcGraphRadarChart extends ezcGraphChart
         {
             --$nr;
             // Determine fill color for dataset
-            if ( $this->options->fillLines !== false )
+            if ( $data->fillLine !== false )
+            {
+                $fillColor = clone $data->color->default;
+                $fillColor->alpha = (int) round( ( 255 - $fillColor->alpha ) * ( $data->fillLine / 255 ) );
+            }
+            else if ( $this->options->fillLines !== false )
             {
                 $fillColor = clone $data->color->default;
                 $fillColor->alpha = (int) round( ( 255 - $fillColor->alpha ) * ( $this->options->fillLines / 255 ) );

--- a/src/datasets/base.php
+++ b/src/datasets/base.php
@@ -37,6 +37,9 @@
  *           Displayed string if a data point is highlighted
  * @property bool $highlight
  *           Status if datapoint element is hilighted
+ * @property mixed $fillLine
+ *           Interpretation depends on underlying chart type
+ *           @see chart type fillLines option for details
  * @property int $displayType
  *           Display type of chart data
  * @property string $url
@@ -110,6 +113,7 @@ abstract class ezcGraphDataSet implements ArrayAccess, Iterator, Countable
         $this->properties['yAxis'] = new ezcGraphDataSetAxisProperty( $this );
 
         $this->properties['highlight']->default = false;
+        $this->properties['fillLine'] = false;
     }
 
     /**
@@ -147,6 +151,21 @@ abstract class ezcGraphDataSet implements ArrayAccess, Iterator, Countable
                 $this->palette = $propertyValue;
                 $this->color->default = $this->palette->dataSetColor;
                 $this->symbol->default = $this->palette->dataSetSymbol;
+                break;
+
+            case 'fillLine':
+                if ( ( $propertyValue !== false ) &&
+                     !is_numeric( $propertyValue ) ||
+                     ( $propertyValue < 0 ) ||
+                     ( $propertyValue > 255 ) )
+                {
+                    throw new ezcBaseValueException( $propertyName, $propertyValue, 'false OR 0 <= int <= 255' );
+                }
+
+                $this->properties[$propertyName] = (
+                    $propertyValue === false
+                    ? false
+                    : (int) $propertyValue );
                 break;
 
             default:

--- a/tests/line_test.php
+++ b/tests/line_test.php
@@ -657,13 +657,8 @@ class ezcGraphLineChartTest extends ezcGraphTestCase
         $chart->render( 500, 200 );
     }
 
-    public function testRenderChartFilledLines()
+    private function getMockedRendererForChartWithFilledLines()
     {
-        $chart = new ezcGraphLineChart();
-        $chart->data['sampleData'] = new ezcGraphArrayDataSet( array( 'sample 1' => 234, 'sample 2' => 21, 'sample 3' => -46, 'sample 4' => 120, 'sample 5'  => 100 ) );
-        $chart->palette = new ezcGraphPaletteBlack();
-        $chart->options->fillLines = 100;
-
         $mockedRenderer = $this->getMock( 'ezcGraphRenderer2d', array(
             'drawDataLine',
         ) );
@@ -713,6 +708,33 @@ class ezcGraphLineChartTest extends ezcGraphTestCase
                 $this->equalTo( ezcGraphColor::fromHex( '#3465A4' ) ),
                 $this->equalTo( ezcGraphColor::fromHex( '#3465A464' ) )
             );
+
+        return $mockedRenderer;
+    }
+
+    public function testRenderChartFilledLines()
+    {
+        $chart = new ezcGraphLineChart();
+        $chart->data['sampleData'] = new ezcGraphArrayDataSet( array( 'sample 1' => 234, 'sample 2' => 21, 'sample 3' => -46, 'sample 4' => 120, 'sample 5'  => 100 ) );
+        $chart->palette = new ezcGraphPaletteBlack();
+        $chart->options->fillLines = 100;
+
+        $mockedRenderer = $this->getMockedRendererForChartWithFilledLines();
+
+        $chart->renderer = $mockedRenderer;
+
+        $chart->render( 500, 200 );
+    }
+
+    public function testRenderChartDataSetFilledLine()
+    {
+        $chart = new ezcGraphLineChart();
+        $chart->data['sampleData'] = new ezcGraphArrayDataSet( array( 'sample 1' => 234, 'sample 2' => 21, 'sample 3' => -46, 'sample 4' => 120, 'sample 5'  => 100 ) );
+        $chart->data['sampleData']->fillLine = 100;
+        $chart->palette = new ezcGraphPaletteBlack();
+        $chart->options->fillLines = 200;
+
+        $mockedRenderer = $this->getMockedRendererForChartWithFilledLines();
 
         $chart->renderer = $mockedRenderer;
 


### PR DESCRIPTION
This PR adds the option to configure if individual datasets should have a filling below their line and at which opacity. This improves the previous functionality of this being available globally for all lines or no line.

```php
        $chart->data['sampleData'] = new ezcGraphArrayDataSet($sampleData);
        $chart->data['sampleData']->fillLine = 100;

        $chart->data['secondData'] = new ezcGraphArrayDataSet($secondData);
        $chart->data['secondData']->fillLine = false;
```
An example rendering is this:

![Screenshot from 2022-01-21 17-21-27](https://user-images.githubusercontent.com/26936/150562625-6a01a7c8-7954-4547-b7b6-ea63987f10b3.png)
