### PR TITLE
New option "labelPosition" on axis to control if label is left or right on secondary axis

### DIFF
--- a/src/element/axis.php
+++ b/src/element/axis.php
@@ -301,8 +301,6 @@ abstract class ezcGraphChartElementAxis extends ezcGraphChartElement
                 break;
             case 'labelPosition':
                 $positions = array(
-                    ezcGraph::TOP,
-                    ezcGraph::BOTTOM,
                     ezcGraph::LEFT,
                     ezcGraph::RIGHT,
                 );

--- a/src/element/axis.php
+++ b/src/element/axis.php
@@ -119,6 +119,8 @@
  *           Size of axis label
  * @property int $labelMargin
  *           Distance between label an axis
+ * @property int $labelPosition
+ *           Integer defining the labels position regarding the axe.
  * @property int $minArrowHeadSize
  *           Minimum Size used to draw arrow heads.
  * @property int $maxArrowHeadSize
@@ -179,6 +181,7 @@ abstract class ezcGraphChartElementAxis extends ezcGraphChartElement
         $this->properties['label'] = false;
         $this->properties['labelSize'] = 14;
         $this->properties['labelMargin'] = 2;
+        $this->properties['labelPosition'] = ezcGraph::LEFT;
         $this->properties['minArrowHeadSize'] = 4;
         $this->properties['maxArrowHeadSize'] = 8;
         $this->properties['labelCallback'] = null;
@@ -295,6 +298,23 @@ abstract class ezcGraphChartElementAxis extends ezcGraphChartElement
                 }
                 
                 $this->properties['labelMargin'] = (int) $propertyValue;
+                break;
+            case 'labelPosition':
+                $positions = array(
+                    ezcGraph::TOP,
+                    ezcGraph::BOTTOM,
+                    ezcGraph::LEFT,
+                    ezcGraph::RIGHT,
+                );
+
+                if ( in_array( $propertyValue, $positions, true ) )
+                {
+                    $this->properties['labelPosition'] = $propertyValue;
+                }
+                else 
+                {
+                    throw new ezcBaseValueException( 'labelPosition', $propertyValue, 'integer' );
+                }
                 break;
             case 'maxArrowHeadSize':
                 if ( !is_numeric( $propertyValue ) ||

--- a/src/renderer/axis_label_exact.php
+++ b/src/renderer/axis_label_exact.php
@@ -207,6 +207,31 @@ class ezcGraphAxisExactLabelRenderer extends ezcGraphAxisLabelRenderer
                         // Skip last step if showLastValue is false
                         $showLabel = false;
                         break;
+                    // NTH : Draw label at top right of step on vertical axis
+                   case ( ( $axis->labelPosition === ezcGraph::RIGHT ) &&
+                        ( !$step->isLast ) ) ||
+                        ( ( $axis->labelPosition === ezcGraph::RIGHT ) &&
+                        ( $step->isLast ) &&
+                        ( $this->renderLastOutside ) ) :
+                        $labelBoundings = new ezcGraphBoundings(
+                            $position->x + $this->labelPadding,
+                            $position->y - $labelHeight + $this->labelPadding,
+                            $position->x + $labelWidth - $this->labelPadding,
+                            $position->y - $this->labelPadding
+                        );
+                        $alignement = ezcGraph::LEFT | ezcGraph::BOTTOM;
+                        break;
+                   case ( ( $axis->labelPosition === ezcGraph::RIGHT ) &&
+                        ( $step->isLast ) &&
+                        ( !$this->renderLastOutside ) ) :
+                        $labelBoundings = new ezcGraphBoundings(
+                            $position->x + $this->labelPadding,
+                            $position->y + $this->labelPadding,
+                            $position->x + $labelWidth - $this->labelPadding,
+                            $position->y + $labelHeight - $this->labelPadding
+                        );
+                        $alignement = ezcGraph::TOP | ezcGraph::LEFT;
+                        break;
                     // Draw label at top left of step
                     case ( ( $axis->position === ezcGraph::BOTTOM ) &&
                            ( !$step->isLast ) ) ||

--- a/src/renderer/axis_label_exact.php
+++ b/src/renderer/axis_label_exact.php
@@ -207,12 +207,11 @@ class ezcGraphAxisExactLabelRenderer extends ezcGraphAxisLabelRenderer
                         // Skip last step if showLastValue is false
                         $showLabel = false;
                         break;
-                    // NTH : Draw label at top right of step on vertical axis
-                   case ( ( $axis->labelPosition === ezcGraph::RIGHT ) &&
-                        ( !$step->isLast ) ) ||
-                        ( ( $axis->labelPosition === ezcGraph::RIGHT ) &&
-                        ( $step->isLast ) &&
-                        ( $this->renderLastOutside ) ) :
+                    case ( ( $axis->labelPosition === ezcGraph::RIGHT ) &&
+                           ( !$step->isLast ) ) ||
+                         ( ( $axis->labelPosition === ezcGraph::RIGHT ) &&
+                           ( $step->isLast ) &&
+                           ( $this->renderLastOutside ) ) :
                         $labelBoundings = new ezcGraphBoundings(
                             $position->x + $this->labelPadding,
                             $position->y - $labelHeight + $this->labelPadding,
@@ -221,9 +220,9 @@ class ezcGraphAxisExactLabelRenderer extends ezcGraphAxisLabelRenderer
                         );
                         $alignement = ezcGraph::LEFT | ezcGraph::BOTTOM;
                         break;
-                   case ( ( $axis->labelPosition === ezcGraph::RIGHT ) &&
-                        ( $step->isLast ) &&
-                        ( !$this->renderLastOutside ) ) :
+                    case ( ( $axis->labelPosition === ezcGraph::RIGHT ) &&
+                           ( $step->isLast ) &&
+                           ( !$this->renderLastOutside ) ) :
                         $labelBoundings = new ezcGraphBoundings(
                             $position->x + $this->labelPadding,
                             $position->y + $this->labelPadding,

--- a/tests/axis_exact_renderer_test.php
+++ b/tests/axis_exact_renderer_test.php
@@ -390,6 +390,49 @@ class ezcGraphAxisExactRendererTest extends ezcGraphTestCase
         $chart->render( 500, 200 );
     }
 
+    public function testRenderTextBoxesWithLabelPositionRight()
+    {
+        $chart = new ezcGraphLineChart();
+        $chart->palette = new ezcGraphPaletteBlack();
+        $chart->xAxis->axisLabelRenderer = new ezcGraphAxisExactLabelRenderer();
+        $chart->xAxis->labelPosition = ezcGraph::RIGHT;
+        $chart->yAxis->axisLabelRenderer = new ezcGraphAxisNoLabelRenderer();
+        $chart->data['sampleData'] = new ezcGraphArrayDataSet( array( 'sample 1' => 234, 'sample 2' => 21, 'sample 3' => 324, 'sample 4' => 120, 'sample 5' => 1) );
+
+        $mockedRenderer = $this->getMock( 'ezcGraphRenderer2d', array(
+            'drawText',
+        ) );
+
+        $mockedRenderer
+            ->expects( $this->at( 0 ) )
+            ->method( 'drawText' )
+            ->with(
+                $this->equalTo( new ezcGraphBoundings( 142., 162., 178., 178. ), 1. ),
+                $this->equalTo( 'sample 1' ),
+                $this->equalTo( ezcGraph::BOTTOM | ezcGraph::LEFT )
+            );
+        $mockedRenderer
+            ->expects( $this->at( 1 ) )
+            ->method( 'drawText' )
+            ->with(
+                $this->equalTo( new ezcGraphBoundings( 222., 162., 258., 178. ), 1. ),
+                $this->equalTo( 'sample 2' ),
+                $this->equalTo( ezcGraph::BOTTOM | ezcGraph::LEFT )
+            );
+        $mockedRenderer
+            ->expects( $this->at( 4 ) )
+            ->method( 'drawText' )
+            ->with(
+                $this->equalTo( new ezcGraphBoundings( 462., 182., 498., 198. ), 1. ),
+                $this->equalTo( 'sample 5' ),
+                $this->equalTo( ezcGraph::TOP | ezcGraph::LEFT )
+            );
+
+        $chart->renderer = $mockedRenderer;
+
+        $chart->render( 500, 200 );
+    }
+
     public function testRenderTextBoxesWithoutLastLabel()
     {
         $chart = new ezcGraphLineChart();

--- a/tests/element_options_test.php
+++ b/tests/element_options_test.php
@@ -652,6 +652,34 @@ class ezcGraphElementOptionsTest extends ezcTestImageCase
         $this->fail( 'Expected ezcBaseValueException.' );
     }
 
+    public function testChartElementAxisPropertyLabelPosition()
+    {
+        $options = new ezcGraphChartElementNumericAxis();
+
+        $this->assertSame(
+            ezcGraph::LEFT,
+            $options->labelPosition,
+            'Wrong default value for property labelPosition in class ezcGraphChartElementNumericAxis'
+        );
+
+        $options->labelPosition = ezcGraph::RIGHT;
+
+        $this->assertSame(
+            ezcGraph::RIGHT,
+            $options->labelPosition,
+            'Setting property value did not work for property labelPosition in class ezcGraphChartElementNumericAxis'
+        );
+
+        try
+        {
+            $options->labelPosition = ezcGraph::TOP;
+        }
+        catch ( ezcBaseValueException $e )
+        {
+            return true;
+        }
+    }
+
     /* Disabled for now.
     public function testChartElementAxisPropertyOuterAxisSpace()
     {


### PR DESCRIPTION
The idea is that on the secondary axis the label should not be on the left (default), because that lets it get rendered into the chart. With its position being right, the label is outside of the charts values:

```php
        $chart = new ezcGraphLineChart();
        $chart->palette = new ezcGraphPaletteBlack();
        $chart->xAxis->axisLabelRenderer = new ezcGraphAxisExactLabelRenderer();
        $chart->xAxis->labelPosition = ezcGraph::RIGHT;
```

The option is a bit misleading right now, because it needs to be combined with `$axis->position` which it interacts with.