### PR TITLE
added property for inline mode to prevent the content type header

### DIFF
--- a/src/driver/svg.php
+++ b/src/driver/svg.php
@@ -1237,7 +1237,9 @@ class ezcGraphSvgDriver extends ezcGraphDriver
         $this->createDocument();
         $this->drawAllTexts();
 
-        header( 'Content-Type: ' . $this->getMimeType() );
+        if (false === $this->options->inline) {
+            header('Content-Type: ' . $this->getMimeType());
+        }
         echo $this->dom->saveXML();
     }
 

--- a/src/options/svg_driver.php
+++ b/src/options/svg_driver.php
@@ -116,6 +116,7 @@ class ezcGraphSvgDriverOptions extends ezcGraphDriverOptions
         $this->properties['graphOffset'] = new ezcGraphCoordinate( 0, 0 );
         $this->properties['idPrefix'] = 'ezcGraph';
         $this->properties['linkCursor'] = 'pointer';
+        $this->properties['inline'] = false;
 
         parent::__construct( $options );
     }
@@ -277,6 +278,9 @@ class ezcGraphSvgDriverOptions extends ezcGraphDriverOptions
                 break;
             case 'linkCursor':
                 $this->properties['linkCursor'] = (string) $propertyValue;
+                break;
+            case 'inline':
+                $this->properties['inline'] = (bool) $propertyValue;
                 break;
             default:
                 parent::__set( $propertyName, $propertyValue );

--- a/src/options/svg_driver.php
+++ b/src/options/svg_driver.php
@@ -88,6 +88,8 @@
  *           Prefix used for the ids in SVG documents.
  * @property string $linkCursor
  *           CSS value for cursor property used for linked SVG elements
+ * @property bool $inline
+ *           Switch to prevent set content type header for inline graphs
  *
  * @version //autogentag//
  * @package Graph


### PR DESCRIPTION
The SVG generation via "renderToOutput" forcibly sets the Content-Type header. When creating the graph document as an inline element, however, the Content-Type should continue to correspond to the master document. With the driver option "inline" no new header is set. Without the option set, the default behaviour remains.