### PR TITLE
resizable SVG graph for responsive documents

### DIFF
--- a/src/driver/svg.php
+++ b/src/driver/svg.php
@@ -170,8 +170,14 @@ class ezcGraphSvgDriver extends ezcGraphDriver
                 $svg = $this->dom->createElementNS( 'http://www.w3.org/2000/svg', 'svg' );
                 $this->dom->appendChild( $svg );
 
-                $svg->setAttribute( 'width', $this->options->width );
-                $svg->setAttribute( 'height', $this->options->height );
+                if (false === $this->options->responsive) {
+                    $svg->setAttribute('viewBox', '0,0,' . $this->options->width . ',' . $this->options->height);
+                    $svg->setAttribute('width', '100%');
+                    $svg->setAttribute('height', '100%');
+                } else {
+                    $svg->setAttribute('width', $this->options->width);
+                    $svg->setAttribute('height', $this->options->height);
+                }
                 $svg->setAttribute( 'version', '1.0' );
                 $svg->setAttribute( 'id', $this->options->idPrefix );
 

--- a/src/options/svg_driver.php
+++ b/src/options/svg_driver.php
@@ -116,6 +116,7 @@ class ezcGraphSvgDriverOptions extends ezcGraphDriverOptions
         $this->properties['graphOffset'] = new ezcGraphCoordinate( 0, 0 );
         $this->properties['idPrefix'] = 'ezcGraph';
         $this->properties['linkCursor'] = 'pointer';
+        $this->properties['responsive'] = false;
 
         parent::__construct( $options );
     }
@@ -277,6 +278,9 @@ class ezcGraphSvgDriverOptions extends ezcGraphDriverOptions
                 break;
             case 'linkCursor':
                 $this->properties['linkCursor'] = (string) $propertyValue;
+                break;
+            case 'responsive':
+                $this->properties['responsive'] = (bool) $propertyValue;
                 break;
             default:
                 parent::__set( $propertyName, $propertyValue );

--- a/tests/data/compare/ezcGraphSvgDriverTest_testRenderToOutputResponsive.svg
+++ b/tests/data/compare/ezcGraphSvgDriverTest_testRenderToOutputResponsive.svg
@@ -1,0 +1,2 @@
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0,0,200,100" width="100%" height="100%" version="1.0" id="ezcGraph"><defs/><g id="ezcGraphChart" color-rendering="optimizeQuality" shape-rendering="geometricPrecision" text-rendering="optimizeLegibility"><path d=" M 12.0000,45.0000 L 134.0000,12.0000" style="fill: none; stroke: #3465a4; stroke-width: 1; stroke-opacity: 1.00; stroke-linecap: round; stroke-linejoin: round;" id="ezcGraphLine_1"/></g></svg>

--- a/tests/driver_svg_test.php
+++ b/tests/driver_svg_test.php
@@ -101,6 +101,35 @@ class ezcGraphSvgDriverTest extends ezcGraphTestCase
         );
     }
 
+    public function testRenderToOutputResponsive()
+    {
+        $filename = $this->tempDir . __FUNCTION__ . '.svg';
+
+        $this->driver->options->responsive = true;
+
+        $this->driver->drawLine(
+            new ezcGraphCoordinate( 12, 45 ),
+            new ezcGraphCoordinate( 134, 12 ),
+            ezcGraphColor::fromHex( '#3465A4' )
+        );
+
+        $this->assertEquals(
+            $this->driver->getMimeType(),
+            'image/svg+xml',
+            'Wrong mime type returned.'
+        );
+
+        ob_start();
+        // Suppress header already sent warning
+        @$this->driver->renderToOutput();
+        file_put_contents( $filename, ob_get_clean() );
+
+        $this->compare(
+            $filename,
+            $this->basePath . 'compare/' . __CLASS__ . '_' . __FUNCTION__ . '.svg'
+        );
+    }
+
     public function testGetResource()
     {
         $this->driver->drawLine(


### PR DESCRIPTION
The generated SVG element is fixed to the size specified at creation. This is not optimal for responsive documents, as the graphic does not adapt. Instead of the absolute width and height specification, a relative specification can be set. An additional viewBox attribute fixes the proportions. The responsive properties can be activated with the driver property "responsive". Without the property set, the previous size definition is used.